### PR TITLE
defaultMenuIconSimplification

### DIFF
--- a/BaselineOfSystemCommands.package/BaselineOfSystemCommands.class/instance/baseline..st
+++ b/BaselineOfSystemCommands.package/BaselineOfSystemCommands.class/instance/baseline..st
@@ -4,7 +4,7 @@ baseline: spec
 
 	spec for: #'common' do: [
 		spec baseline: 'Commander' with: [
-				spec repository: 'github://dionisiydk/Commander:v0.3.x' ].
+				spec repository: 'github://dionisiydk/Commander:v0.4.x' ].
 		spec
 			package: #'SystemCommands-RefactoringSupport' with: [
 				spec requires: #('Commander' ). ]; 

--- a/SystemCommands-ClassCommands.package/SycAddNewMethodTagCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-ClassCommands.package/SycAddNewMethodTagCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#add

--- a/SystemCommands-ClassCommands.package/SycAddNewMethodTagCommand.class/instance/prepareFullExecutionInContext..st
+++ b/SystemCommands-ClassCommands.package/SycAddNewMethodTagCommand.class/instance/prepareFullExecutionInContext..st
@@ -3,9 +3,6 @@ prepareFullExecutionInContext: aToolContext
 	super prepareFullExecutionInContext: aToolContext.
 	
 	tagName := aToolContext requestSingleMethodTag: 'New protocol name'.
-	(tagName beginsWith: '*') ifTrue: [ 
-		self inform: 'Star is forbidden for protocol name. You can specify package in method editor using status bar checkbox'.
-		^CmdCommandAborted signal].
 	
 	targetClass := self requestClassInContext: aToolContext.
 	targetClass := aToolContext currentMetaLevelOf: targetClass

--- a/SystemCommands-ClassCommands.package/SycAddNewMethodTagCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-ClassCommands.package/SycAddNewMethodTagCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-initialization
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #add forMenuItem: aMenuItemMorph

--- a/SystemCommands-ClassCommands.package/SycAddSubclassCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-ClassCommands.package/SycAddSubclassCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#add

--- a/SystemCommands-ClassCommands.package/SycAddSubclassCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-ClassCommands.package/SycAddSubclassCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-initialization
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #add forMenuItem: aMenuItemMorph

--- a/SystemCommands-ClassCommands.package/SycRemoveClassCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-ClassCommands.package/SycRemoveClassCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#removeIcon

--- a/SystemCommands-ClassCommands.package/SycRemoveClassCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-ClassCommands.package/SycRemoveClassCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-menu support
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #removeIcon forMenuItem: aMenuItemMorph

--- a/SystemCommands-MethodCommands.package/SycRemoveMethodCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-MethodCommands.package/SycRemoveMethodCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#removeIcon

--- a/SystemCommands-MethodCommands.package/SycRemoveMethodCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-MethodCommands.package/SycRemoveMethodCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-menu support
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #removeIcon forMenuItem: aMenuItemMorph

--- a/SystemCommands-MethodCommands.package/SycShowMethodVersionCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-MethodCommands.package/SycShowMethodVersionCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#history

--- a/SystemCommands-MethodCommands.package/SycShowMethodVersionCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-MethodCommands.package/SycShowMethodVersionCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-menu support
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #history forMenuItem: aMenuItemMorph

--- a/SystemCommands-MethodCommands.package/SycTagMethodCommand.class/class/for.tag..st
+++ b/SystemCommands-MethodCommands.package/SycTagMethodCommand.class/class/for.tag..st
@@ -1,0 +1,5 @@
+instance creation
+for: methods tag: aString
+
+	^(self for: methods)
+		targetTag: aString

--- a/SystemCommands-MethodCommands.package/SycTagMethodCommand.class/instance/prepareFullExecutionInContext..st
+++ b/SystemCommands-MethodCommands.package/SycTagMethodCommand.class/instance/prepareFullExecutionInContext..st
@@ -2,4 +2,4 @@ execution
 prepareFullExecutionInContext: aToolContext
 	super prepareFullExecutionInContext: aToolContext.
 	
-	targetTag := aToolContext requestSingleMethodTag: 'New tag name'
+	targetTag := aToolContext requestSingleMethodTag: 'New protocol name'

--- a/SystemCommands-PackageCommands.package/SycAddNewPackageCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-PackageCommands.package/SycAddNewPackageCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#add

--- a/SystemCommands-PackageCommands.package/SycAddNewPackageCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-PackageCommands.package/SycAddNewPackageCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-initialization
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #add forMenuItem: aMenuItemMorph

--- a/SystemCommands-PackageCommands.package/SycRemovePackageCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-PackageCommands.package/SycRemovePackageCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#removeIcon

--- a/SystemCommands-PackageCommands.package/SycRemovePackageCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-PackageCommands.package/SycRemovePackageCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-menu support
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #removeIcon forMenuItem: aMenuItemMorph

--- a/SystemCommands-VariableCommands.package/SycRemoveVariableCommand.class/class/defaultMenuIconName.st
+++ b/SystemCommands-VariableCommands.package/SycRemoveVariableCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#removeIcon

--- a/SystemCommands-VariableCommands.package/SycRemoveVariableCommand.class/class/defaultMenuItemName.st
+++ b/SystemCommands-VariableCommands.package/SycRemoveVariableCommand.class/class/defaultMenuItemName.st
@@ -1,3 +1,3 @@
-as yet unclassified
+accessing
 defaultMenuItemName
 	^'Remove'

--- a/SystemCommands-VariableCommands.package/SycRemoveVariableCommand.class/instance/setUpIconForMenuItem..st
+++ b/SystemCommands-VariableCommands.package/SycRemoveVariableCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-menu support
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #removeIcon forMenuItem: aMenuItemMorph


### PR DESCRIPTION
Now any command understand defaultMenuIcon which by default ask uses icon name from class side (defaultMenuIconName).
They both can return nil which is default value.

Also additional method is added for the cases when real icon instance should be ensured: #secureMenuIcon. In case if missin icon it returnes error icon.

And CmdCommandActivator is now understands menuItemIcon.
All commands are adopted to this simplification