### PR TITLE
betterLogicForChangingMessageSignature

### DIFF
--- a/SystemCommands-MessageCommands.package/SycChangeMessageSignatureCommand.class/instance/applyResultInContext..st
+++ b/SystemCommands-MessageCommands.package/SycChangeMessageSignatureCommand.class/instance/applyResultInContext..st
@@ -2,6 +2,4 @@ execution
 applyResultInContext: aToolContext
 	super applyResultInContext: aToolContext.
 
-	aToolContext tool 
-		selectMessage: originalMessage 
-		withNewSelector: self resultMessageSelector asSymbol
+	aToolContext showMessage: originalMessage renamedTo: self resultMessageSelector asSymbol


### PR DESCRIPTION
now method signature command asks  context to showMessage:renamedTo:  instead of previous tool based message.